### PR TITLE
editor is not defined, better to use atom.project.getPath()

### DIFF
--- a/lib/linter-tslint.coffee
+++ b/lib/linter-tslint.coffee
@@ -18,8 +18,8 @@ class LinterTslint extends Linter
 
   linterName: 'tslint'
 
-  constructor: (editor) ->
-    @cwd = path.dirname(editor.getUri())
+  constructor: () ->
+    @cwd = atom.project.getPath()
     @executablePath = atom.config.get 'linter-tslint.tslintExecutablePath'
 
   getCmd:(filePath) ->


### PR DESCRIPTION
I'm getting an error starting atom because when Linter starts it constructs linter plugins without passing anything to constructors. I think `atom.project.getPath()` will serve the same purpose.
